### PR TITLE
Add PKCE OAuth login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,25 @@
 import { useState } from 'react'
+import { useAuth } from './auth/AuthProvider'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
+  const { auth, login, logout } = useAuth()
 
   return (
     <>
+      <div className="auth">
+        {auth.user ? (
+          <>
+            <p>Signed in as {(auth.user as any).email ?? 'User'}</p>
+            <button onClick={logout}>Logout</button>
+          </>
+        ) : (
+          <button onClick={login}>Login</button>
+        )}
+      </div>
       <div>
         <a href="https://vite.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,0 +1,120 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { decodeJwt, randomString } from './utils'
+import { generateCodeChallenge, generateCodeVerifier } from './pkce'
+
+const AUTH_ENDPOINT = 'https://auth.hyperc.tr/application/o/authorize/'
+const TOKEN_ENDPOINT = 'https://auth.hyperc.tr/application/o/token/'
+const CLIENT_ID = 'b2fS6rmY8JzD80iVplmaBq6ylM6xzKi73nEh9TVd'
+const REDIRECT_URI = 'http://localhost:5173'
+const SCOPES = 'openid email profile'
+
+export interface AuthState {
+  accessToken?: string
+  idToken?: string
+  user?: unknown
+}
+
+interface Context {
+  auth: AuthState
+  login: () => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<Context | undefined>(undefined)
+
+export const useAuth = (): Context => {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('AuthContext not ready')
+  return ctx
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [auth, setAuth] = useState<AuthState>(() => {
+    const accessToken = localStorage.getItem('access_token') ?? undefined
+    const idToken = localStorage.getItem('id_token') ?? undefined
+    return {
+      accessToken,
+      idToken,
+      user: idToken ? decodeJwt(idToken) : undefined,
+    }
+  })
+
+  async function login() {
+    const state = randomString(16)
+    const verifier = generateCodeVerifier()
+    const challenge = await generateCodeChallenge(verifier)
+
+    sessionStorage.setItem('pkce_state', state)
+    sessionStorage.setItem('pkce_verifier', verifier)
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      scope: SCOPES,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    })
+
+    window.location.href = `${AUTH_ENDPOINT}?${params.toString()}`
+  }
+
+  function logout() {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('id_token')
+    setAuth({})
+  }
+
+  async function handleRedirect() {
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('code')
+    const state = params.get('state')
+    if (!code) return
+    const storedState = sessionStorage.getItem('pkce_state')
+    const verifier = sessionStorage.getItem('pkce_verifier')
+    sessionStorage.removeItem('pkce_state')
+    sessionStorage.removeItem('pkce_verifier')
+    if (!verifier || !storedState || storedState !== state) return
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: verifier,
+    })
+
+    const res = await fetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+
+    if (!res.ok) {
+      console.error('Token request failed')
+      return
+    }
+
+    const tokens = await res.json()
+    const { access_token, id_token } = tokens
+    if (access_token) localStorage.setItem('access_token', access_token)
+    if (id_token) localStorage.setItem('id_token', id_token)
+    setAuth({
+      accessToken: access_token,
+      idToken: id_token,
+      user: id_token ? decodeJwt(id_token) : undefined,
+    })
+    window.history.replaceState({}, '', '/')
+  }
+
+  useEffect(() => {
+    handleRedirect().catch(console.error)
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ auth, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/auth/pkce.ts
+++ b/src/auth/pkce.ts
@@ -1,0 +1,20 @@
+export function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let str = '';
+  for (const byte of bytes) {
+    str += String.fromCharCode(byte);
+  }
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return base64UrlEncode(array.buffer);
+}
+
+export async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+  const data = new TextEncoder().encode(codeVerifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(digest);
+}

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,0 +1,17 @@
+export function randomString(length: number): string {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function decodeJwt(token: string): unknown {
+  const [, payload] = token.split('.');
+  const decoded = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+  const json = decodeURIComponent(
+    decoded
+      .split('')
+      .map((c) => `%${c.charCodeAt(0).toString(16).padStart(2, '0')}`)
+      .join(''),
+  );
+  return JSON.parse(json);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './auth/AuthProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add PKCE helper functions
- create AuthProvider with login/logout and token exchange
- display login/logout in App
- wrap app in AuthProvider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843e1a2e26483218c6440d338f7468a